### PR TITLE
Use npm-style "license" metadata property

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/jonschlinkert/romanize/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/jonschlinkert/romanize/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "index.js",
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
This tiny PR changes the current Ruby-style "licenses" array in `package.json` to an npm-style "license" string.

It's a trifle, but it makes life easier for those checking license compliance with software.

See https://docs.npmjs.com/files/package.json#license

Thanks so much for this package. I've used it in some of my own work automating numbering of contract provisions.

Best,

K
